### PR TITLE
fix: handle address-already-in-use gracefully

### DIFF
--- a/server.py
+++ b/server.py
@@ -495,13 +495,13 @@ examples:
             )
             sys.exit(1)
     else:
-        max_attempts = 10
-        for attempt in range(max_attempts):
+        MAX_PORT_ATTEMPTS = 10
+        for attempt in range(MAX_PORT_ATTEMPTS):
             try:
                 server = _ReuseAddrHTTPServer((args.bind, port), DashboardHandler)
                 break
             except OSError:
-                if attempt < max_attempts - 1:
+                if attempt < MAX_PORT_ATTEMPTS - 1:
                     print(f"[dashboard] Port {port} in use, trying {port + 1}…")
                     port += 1
                 else:


### PR DESCRIPTION
## Summary
- Fix `SO_REUSEADDR` timing — applied before bind via `HTTPServer` subclass instead of after
- When `-p` is explicitly passed and the port is taken, exit with code 1 and a clear error message
- When using the default port (no `-p`), auto-advance to the next available port (up to 10 attempts)

## Test plan
- [x] `test_explicit_port_exits_with_error` — occupies a port, starts server with `-p`, asserts exit 1 + "already in use" in stderr
- [x] `test_default_port_auto_advances` — occupies a port via env var (no `-p`), asserts server starts on port+1 with log output