### PR TITLE
fix: prevent negative cost totals in dashboard aggregation

### DIFF
--- a/refresh.sh
+++ b/refresh.sh
@@ -611,7 +611,13 @@ for f in glob.glob(os.path.join(base, '*/sessions/*.jsonl')) + glob.glob(os.path
                     if 'delivery-mirror' in model: continue
 
                     name = model_name(model)
-                    cost_total = usage.get('cost',{}).get('total',0) if isinstance(usage.get('cost'),dict) else 0
+                    raw_cost_total = usage.get('cost',{}).get('total',0) if isinstance(usage.get('cost'),dict) else 0
+                    try:
+                        raw_cost_total = float(raw_cost_total)
+                    except (TypeError, ValueError):
+                        raw_cost_total = 0.0
+                    # Guard against negative provider adjustments/credits appearing as spend.
+                    cost_total = max(0.0, raw_cost_total)
                     inp = usage.get('input',0)
                     out = usage.get('output',0)
                     cr = usage.get('cacheRead',0)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -120,6 +120,11 @@ class TestRefreshShSafety(unittest.TestCase):
         if bare_opens:
             self.fail(f"Found {len(bare_opens)} bare json.load(open(...)) without context manager")
 
+    def test_ac30_negative_costs_are_clamped_in_refresh(self):
+        """AC30: refresh.sh clamps negative usage.cost.total to 0.0."""
+        self.assertIn("cost_total = max(0.0, raw_cost_total)", self.sh)
+
+
 
 class TestServerSafety(unittest.TestCase):
     """AC23: server.py safety checks."""


### PR DESCRIPTION
## Summary\n- clamp per-message `usage.cost.total` to non-negative before aggregation\n- prevent credits/adjustments from producing negative dashboard spend cards\n- add regression test for negative-cost clamp in `refresh.sh`\n\n## Why\nIssue #5 reports negative total cost on the board. Provider payloads can include negative adjustments, which should not drive spend metrics below zero in this dashboard context.\n\n## Test plan\n- [x] `pytest -q tests/test_frontend.py::TestRefreshShSafety::test_ac30_negative_costs_are_clamped_in_refresh`\n\nFixes #5