### PR TITLE
Update GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Validate issue is not blank
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const body = context.payload.issue.body || '';

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate PR description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const body = context.payload.pull_request.body || '';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,16 +13,16 @@ jobs:
     name: Build and release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,13 +11,13 @@ jobs:
     name: GolangCI-Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -25,9 +25,9 @@ jobs:
     name: Go test suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -44,7 +44,7 @@ jobs:
     name: Lint shell scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck


### PR DESCRIPTION
## Summary

- update GitHub Actions workflow pins to Node 24-compatible majors
- remove the deprecation warning surfaced during the v2026.4.13 release workflow
- keep CI and release automation aligned across release, test, PR validation, and issue labeling workflows

## What Changed

| File | Change |
| --- | --- |
| `.github/workflows/release.yml` | Upgrade `actions/checkout`, `actions/setup-go`, and `goreleaser/goreleaser-action` |
| `.github/workflows/tests.yml` | Upgrade `actions/checkout`, `actions/setup-go`, and `golangci/golangci-lint-action` |
| `.github/workflows/pr-validate.yml` | Upgrade `actions/github-script` |
| `.github/workflows/label-issues.yml` | Upgrade `actions/github-script` |

## Checklist

- [x] Change is scoped to workflow maintenance only
- [x] No application behavior changes
- [x] Versions selected from current upstream Node 24-compatible majors
- [x] Ready for review
