### PR TITLE
docs: add TweetClaw workflow example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Documentation
+
+- **TweetClaw workflow example** - documents how to pair OpenClaw Dashboard with `@xquik/tweetclaw` so users can monitor sessions, crons, costs, and configured skills for X/Twitter automation work.
+
 ## v2026.5.13 — 2026-05-13
 
 Code-review fixes (waves 1–4) and security hardening pass. No new features.

--- a/README.md
+++ b/README.md
@@ -480,6 +480,23 @@ The chat is stateless — each question is sent directly to the gateway with a s
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for full details.
 
+### Example: Monitor X/Twitter Automation
+
+If an OpenClaw agent handles public X/Twitter work, install TweetClaw as the
+action plugin and use OpenClaw Dashboard to watch the matching agent session,
+cron status, token usage, configured skills, and cost trend while it runs.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+TweetClaw covers API-backed tweet search, reply search, follower export, user
+lookup, media upload/download, direct messages, monitors, webhooks, giveaway
+draws, and approval-gated posts or replies. See the
+[GitHub repo](https://github.com/Xquik-dev/tweetclaw),
+[npm package](https://www.npmjs.com/package/@xquik/tweetclaw), and
+[ClawHub listing](https://clawhub.ai/plugins/@xquik/tweetclaw).
+
 ## Screenshots
 
 Full dashboard view — all sections at a glance:


### PR DESCRIPTION
## Type

- [x] `docs` - documentation only

## Summary

Adds a focused README workflow example for running TweetClaw as the OpenClaw action plugin for public X/Twitter automation, then using OpenClaw Dashboard to monitor sessions, cron status, token usage, configured skills, and cost trend. The changelog records the docs-only addition under Unreleased.

## What Changed

| File | What changed |
|------|-------------|
| `README.md` | Added an X/Twitter automation monitoring example with the `openclaw plugins install @xquik/tweetclaw` command and GitHub, npm, and ClawHub links. |
| `CHANGELOG.md` | Added an Unreleased documentation note for the TweetClaw workflow example. |

## Test Evidence

- `git diff --check`
- README link check: 12 external links checked, 0 failures
- TweetClaw changed-link checks: GitHub 200, ClawHub 200, npm package verified by `npm view @xquik/tweetclaw version` returning `1.6.29`; npm web page returned 403 to automated probe
- `go vet ./...` ran as part of `make check` before the lint step
- `go test -race -count=1 ./...`
- `make check` could not complete because `golangci-lint` is not installed in this local environment

## Checklist

### Code quality
- [x] No new globals outside the 7 module objects + 4 utilities (`$`, `esc`, `safeColor`, `relTime`)
- [x] Every dynamic value inserted into the DOM goes through `esc()`
- [x] No hardcoded hex colors - CSS variables only (`var(--accent)`, etc.)
- [x] No new frontend dependencies (no `import`, no CDN `<script>`)
- [x] No new Go module dependencies (`go.mod` stays stdlib-only)

### Tests
- [x] All existing tests pass: `go test -race ./...`
- [x] New behaviour has at least one test: documentation-only change, no runtime behavior changed

### Manual verification
- [x] Tested in at least one dark theme and one light theme: documentation-only change, no UI changed
- [x] Tested on desktop and mobile viewport (< 768px): documentation-only change, no UI changed
- [x] If chart code changed: not applicable
- [x] If session/cron table changed: not applicable

### Documentation
- [x] `CHANGELOG.md` updated under the correct version heading
- [x] `README.md` updated if a new panel or config key was added

## Screenshots / Recordings

Documentation-only change.

## Breaking Changes

None.

## Agent Review Notes

Please verify whether this example belongs near AI Chat Setup or should move closer to the skills panel section.
