### PR TITLE
ci(release): migrate create-github-app-token app-id → client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,12 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: tap-token
         with:
-          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          # `client-id` replaces the deprecated `app-id` input. The existing
+          # HOMEBREW_TAP_APP_ID secret (the numeric App ID) is still valid here:
+          # GitHub accepts either the numeric App ID or the App's Client ID as
+          # the JWT issuer when authenticating as a GitHub App, so no secret
+          # change is required to silence the deprecation warning.
+          client-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
           private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
           owner: mudrii
           repositories: homebrew-tap


### PR DESCRIPTION
## Type

- [x] `chore` — tooling, CI, config

## Summary

Forward-looking CI cleanup from the v2026.6.1 release run. Migrates the homebrew-tap token step off the deprecated `app-id` input of `actions/create-github-app-token@v3` to `client-id`, silencing the deprecation annotation. No secret change required — GitHub accepts the numeric App ID in `HOMEBREW_TAP_APP_ID` as the JWT issuer under either input name. Takes effect on the next release tag.

## What Changed

| File | What changed |
|------|-------------|
| `.github/workflows/release.yml` | `app-id:` → `client-id:` on the `Mint homebrew-tap token` step; same `HOMEBREW_TAP_APP_ID` secret; added a comment explaining why no secret change is needed |

## Test Evidence

```
go test -race -v ./...
```

<details>
<summary>Test output</summary>

```
No Go code changed — CI-config only. release.yml validated as well-formed YAML;
the token step now exposes inputs: client-id, private-key, owner, repositories.
Effect is verifiable only on the next release run (tag push). The v2026.6.1
release used app-id successfully, and the migrated input passes the same value.
```

</details>

## Checklist

### Code quality
- [x] No new globals — N/A, CI config only
- [x] Every dynamic value through `esc()` — N/A, no frontend
- [x] No hardcoded hex colors — N/A, no CSS
- [x] No new frontend dependencies — none
- [x] No new Go module dependencies — none (no Go change)

### Tests
- [x] All existing tests pass: `go test -race ./...` — unaffected, no code change
- [x] New behaviour has at least one test — N/A, CI-config deprecation rename only

### Manual verification
- [x] Tested in dark + light theme — N/A, no UI
- [x] Tested desktop + mobile viewport — N/A, no UI
- [x] If chart code changed — N/A, no chart change
- [x] If session/cron table changed — N/A, no table change

### Documentation
- [x] `CHANGELOG.md` updated — N/A, no user-facing or behavioral change (CI deprecation cleanup)
- [x] `README.md` updated if a new panel or config key was added — N/A, none added

## Screenshots / Recordings

N/A — CI configuration change.

## Breaking Changes

None. The release pipeline behavior is unchanged; only the GitHub Actions input key name is updated. The same secret value authenticates the GitHub App.

## Agent Review Notes

The companion annotation from the same run — cosign "skipping signature verification: 404 sigstore bundle" — was investigated and is **not** actionable here: it originates inside `sigstore/cosign-installer` self-verifying its own downloaded binary (transient sigstore infra), not this repo's signing step. The release's `checksums-sha256.txt.bundle` signature is produced and attached correctly, so no change is warranted for that warning.
